### PR TITLE
fix: withAuth redirect issue

### DIFF
--- a/src/hoc/withAuth.tsx
+++ b/src/hoc/withAuth.tsx
@@ -17,11 +17,12 @@ export function withAuth<P extends object>(
   const { allowedRoles, redirectTo = "/login" } = options;
 
   const WithAuthComponent: React.FC<P> = (props) => {
-    const { user, isSuccess } = useAuthState();
+    const { user, isLoading } = useAuthState();
     const router = useRouter();
 
     useEffect(() => {
-      if (isSuccess) {
+      // Only redirect after initial auth check is complete
+      if (!isLoading) {
         if (!user) {
           router.push(redirectTo);
           return;
@@ -36,9 +37,26 @@ export function withAuth<P extends object>(
           }
         }
       }
-    }, [isSuccess, user, allowedRoles, redirectTo, router]);
+    }, [isLoading, user, allowedRoles, redirectTo, router]);
 
-    if (!isSuccess || !user) {
+    // Show loading spinner while initial auth check is in progress
+    if (isLoading) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: "100vh",
+          }}
+        >
+          <Spin size="large" />
+        </div>
+      );
+    }
+
+    // If not loading and no user, the useEffect will handle redirect
+    if (!user) {
       return (
         <div
           style={{

--- a/src/providers/authProvider/actions.tsx
+++ b/src/providers/authProvider/actions.tsx
@@ -12,16 +12,28 @@ export enum AuthActionEnums {
   loginUserError = "LOGIN_USER_ERROR",
   //logout user
   logoutUser = "LOGOUT_USER",
+  //set loading
+  setAuthLoading = "SET_AUTH_LOADING",
 }
 
 //register user
 export const registerUserPending = createAction<IAuthStateContext>(
   AuthActionEnums.registerUserPending,
-  () => ({ isPending: true, isError: false, isSuccess: false }),
+  () => ({
+    isPending: true,
+    isError: false,
+    isSuccess: false,
+    isLoading: false,
+  }),
 );
 export const registerUserError = createAction<IAuthStateContext>(
   AuthActionEnums.registerUserError,
-  () => ({ isPending: false, isError: true, isSuccess: false }),
+  () => ({
+    isPending: false,
+    isError: true,
+    isSuccess: false,
+    isLoading: false,
+  }),
 );
 export const registerUserSuccess = createAction<IAuthStateContext, IUser>(
   AuthActionEnums.registerUserSuccess,
@@ -29,6 +41,7 @@ export const registerUserSuccess = createAction<IAuthStateContext, IUser>(
     isPending: false,
     isError: false,
     isSuccess: true,
+    isLoading: false,
     user,
   }),
 );
@@ -36,11 +49,21 @@ export const registerUserSuccess = createAction<IAuthStateContext, IUser>(
 //login user
 export const loginUserPending = createAction<IAuthStateContext>(
   AuthActionEnums.loginUserPending,
-  () => ({ isPending: true, isError: false, isSuccess: false }),
+  () => ({
+    isPending: true,
+    isError: false,
+    isSuccess: false,
+    isLoading: false,
+  }),
 );
 export const loginUserError = createAction<IAuthStateContext>(
   AuthActionEnums.loginUserError,
-  () => ({ isPending: false, isError: true, isSuccess: false }),
+  () => ({
+    isPending: false,
+    isError: true,
+    isSuccess: false,
+    isLoading: false,
+  }),
 );
 export const loginUserSuccess = createAction<IAuthStateContext, IUser>(
   AuthActionEnums.loginUserSuccess,
@@ -48,6 +71,7 @@ export const loginUserSuccess = createAction<IAuthStateContext, IUser>(
     isPending: false,
     isError: false,
     isSuccess: true,
+    isLoading: false,
     user,
   }),
 );
@@ -59,6 +83,18 @@ export const logoutUser = createAction<IAuthStateContext>(
     isPending: false,
     isError: false,
     isSuccess: false,
+    isLoading: false,
     user: undefined,
+  }),
+);
+
+//set loading (initial auth check complete)
+export const setAuthLoading = createAction<IAuthStateContext, boolean>(
+  AuthActionEnums.setAuthLoading,
+  (isLoading: boolean) => ({
+    isLoading,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
   }),
 );

--- a/src/providers/authProvider/context.tsx
+++ b/src/providers/authProvider/context.tsx
@@ -16,6 +16,7 @@ export interface IAuthStateContext {
   isPending: boolean;
   isSuccess: boolean;
   isError: boolean;
+  isLoading: boolean;
   user?: IUser;
 }
 
@@ -29,6 +30,7 @@ export const INITIAL_STATE: IAuthStateContext = {
   isPending: false,
   isSuccess: false,
   isError: false,
+  isLoading: true,
 };
 
 export const AuthStateContext = createContext<IAuthStateContext>(INITIAL_STATE);

--- a/src/providers/authProvider/index.tsx
+++ b/src/providers/authProvider/index.tsx
@@ -9,6 +9,7 @@ import {
   registerUserPending,
   registerUserSuccess,
   logoutUser,
+  setAuthLoading,
 } from "./actions";
 import {
   AuthActionContext,
@@ -37,6 +38,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           removeAuthToken();
         }
       }
+      // Mark initial auth check as complete (regardless of whether user is logged in)
+      dispatch(setAuthLoading(false));
     }
   }, []);
 

--- a/src/providers/authProvider/reducer.tsx
+++ b/src/providers/authProvider/reducer.tsx
@@ -32,6 +32,10 @@ export const AuthReducer = handleActions<IAuthStateContext, IAuthStateContext>(
       ...state,
       ...action.payload,
     }),
+    [AuthActionEnums.setAuthLoading]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
   },
   INITIAL_STATE,
 );


### PR DESCRIPTION
Fixed the withAuth redirect issue by adding an isLoading state to track initial auth check completion. Now unauthenticated users are properly redirected to login instead of showing infinite loading.